### PR TITLE
Added debug symbol support

### DIFF
--- a/src/NuGetTasks/More.Build.Tasks.NuGet.targets
+++ b/src/NuGetTasks/More.Build.Tasks.NuGet.targets
@@ -31,8 +31,10 @@
          by default. a project might choose to opt out of packing the project if the target output is not
          an assembly. for example, the same build features can be used to generate project and item templates. -->
   <PackAfterBuild Condition=" '$(PackAfterBuild)' == '' ">true</PackAfterBuild>
+  <IncludeSymbols Condition=" '$(IncludeSymbols)' == '' ">false</IncludeSymbols>
+  <Symbols Condition=" '$(IncludeSymbols)' != 'false' ">-Symbols</Symbols>
 
-  <NuGetExe Condition=" '$(NuGetExe)' == '' ">$([System.IO.Path]::GetFullPath(`$(MSBuildThisFileDirectory)..\..\..\NuGet.CommandLine.3.3.0\tools\nuget.exe`))</NuGetExe>
+  <NuGetExe Condition=" '$(NuGetExe)' == '' ">$([System.IO.Path]::GetFullPath(`$(MSBuildThisFileDirectory)..\..\..\NuGet.CommandLine.3.5.0\tools\nuget.exe`))</NuGetExe>
   <PackageOutDir Condition=" '$(PackageOutDir)' == '' ">$([System.IO.Path]::GetFullPath(`$(MSBuildThisFileDirectory)..\..\..\..`))\NuGet</PackageOutDir>
   <PackageOutDir>$(PackageOutDir.TrimEnd(`\`))</PackageOutDir>
   <NuGetPackTarget Condition=" '$(NuGetPackTarget)' == '' ">$(ProjectPath)</NuGetPackTarget>
@@ -129,7 +131,7 @@
   <MakeDir Condition="!Exists('$(PackageOutDir)')" Directories="$(PackageOutDir)" />
 
   <!-- create packages -->
-  <Exec Command="&quot;$(NuGetExe)&quot; pack &quot;$(NuGetPackTarget)&quot; -Properties &quot;$(NuGetPackProperties)&quot; -OutputDirectory &quot;$(PackageOutDir)&quot; $(_IncludeReferencedProjects) -NoPackageAnalysis -NonInteractive -Verbosity quiet" />
+  <Exec Command="&quot;$(NuGetExe)&quot; pack &quot;$(NuGetPackTarget)&quot; -Properties &quot;$(NuGetPackProperties)&quot; -OutputDirectory &quot;$(PackageOutDir)&quot; $(_IncludeReferencedProjects) -NoPackageAnalysis -NonInteractive -Verbosity quiet $(Symbols)" />
 
  </Target>
 

--- a/src/NuGetTasks/NuGetTasks.csproj
+++ b/src/NuGetTasks/NuGetTasks.csproj
@@ -230,7 +230,7 @@
   <Target Name="AfterBuild">
     <MakeDir Condition="!Exists('..\NuGet')" Directories="..\NuGet" />
     <PropertyGroup>
-      <NuGetExe>..\packages\NuGet.CommandLine.3.3.0\tools\nuget.exe</NuGetExe>
+      <NuGetExe>..\packages\NuGet.CommandLine.3.5.0\tools\nuget.exe</NuGetExe>
       <NuSpec>$(ProjectDir)$(ProjectName).nuspec</NuSpec>
       <NuGetProperties>id=$(TargetName);configuration=$(Configuration)</NuGetProperties>
     </PropertyGroup>

--- a/src/NuGetTasks/Properties/AssemblyInfo.cs
+++ b/src/NuGetTasks/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion( "1.0.0.0" )]
-[assembly: AssemblyInformationalVersion( "1.0.3" )]
+[assembly: AssemblyInformationalVersion( "1.0.4" )]
 [assembly: AssemblyTitle( "More.Build.Tasks.NuGet" )]
 [assembly: AssemblyProduct( "More.Build.Tasks.NuGet" )]
 [assembly: AssemblyDescription( "Microsoft Build tasks used to create NuGet packages and their references." )]

--- a/src/NuGetTasks/nugettasks.nuspec
+++ b/src/NuGetTasks/nugettasks.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="2.5">
     <id>$id$</id>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <authors>Chris Martinez</authors>
     <owners>Commonsense Software</owners>
     <title>More NuGet Build Tasks</title>
     <description>Microsoft Build tasks used to create NuGet packages and their references.</description>
     <summary>Provides MSBuild tasks for creating NuGet packages (*.nupkg). These tasks also integrate with T4 templates (*.tt) so that you can keep the version numbers of dependent packages in your solution up-to-date during the build process.</summary>
-    <releaseNotes>• Added missing condition to NuGetPackTarget to allows overrides</releaseNotes>
+    <releaseNotes>• Added support for including debugging symbols</releaseNotes>
     <language>en-US</language>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <licenseUrl>https://raw.githubusercontent.com/commonsensesoftware/More.Build/master/LICENSE</licenseUrl>
@@ -18,7 +18,7 @@
     <copyright>Commonsense Software</copyright>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="NuGet.CommandLine" version="3.3.0" />
+      <dependency id="NuGet.CommandLine" version="3.5.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/NuGetTasks/packages.config
+++ b/src/NuGetTasks/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net46" />
+  <package id="NuGet.CommandLine" version="3.5.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Can now add `<IncludeSymbols>` property to your project to include source and PDBs (simply appends `-Symbols` to the command line).
Also bumped NuGet.CommandLine to 3.5.0