### PR TITLE
Fixed the NuGet.CommandLine dependency version so it is fixed

### DIFF
--- a/src/NuGetTasks/nugettasks.nuspec
+++ b/src/NuGetTasks/nugettasks.nuspec
@@ -24,7 +24,7 @@
     <copyright>Commonsense Software</copyright>
     <developmentDependency>true</developmentDependency>
     <dependencies>
-      <dependency id="NuGet.CommandLine" version="3.5.0" />
+      <dependency id="NuGet.CommandLine" version="[3.5.0]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Changed the nuspec to have a fixed version reference to the NuGet.CommandLine 3.5